### PR TITLE
Fixed OSTYPE check for when linux is reported as 'linux' instead of 'linux-gnu'

### DIFF
--- a/dltools.sh
+++ b/dltools.sh
@@ -42,7 +42,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     fi
 
 # Linux (x86_64)
-elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+elif [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "linux" ]]; then
     echo " * Downloading ${BOLD}ctrdecrypt${NORMAL}"
     wget "https://github.com/shijimasoft/ctrdecrypt/releases/download/v${CTRDECRYPT_VER}/ctrdecrypt-linux-x86_64.zip" -q
     echo " * Extracting ${BOLD}ctrdecrypt${NORMAL}"


### PR DESCRIPTION
the OSTYPE env var doesn't always have the "linux-gnu" value. Sometimes (as in openSUSE Tumbleweed) the value is "linux", and this PR adds a check for that.