### PR TITLE
Be flexible regarding bash path in dltools.sh

### DIFF
--- a/dltools.sh
+++ b/dltools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 BOLD=$(tput bold)


### PR DESCRIPTION
Bash isn't always at /bin/bash. On nixos, it might be a nix store path. On macOS, users might want to use a more up-to-date version of bash than what ships with the system (bash 3, from 2007).

Locate bash from PATH instead.

---

Great project btw!