### PR TITLE
Output `.cia` files, not just `.cci` files

### DIFF
--- a/cia-unix.cr
+++ b/cia-unix.cr
@@ -65,7 +65,6 @@ end
 # cache cleanup
 def remove_cache
     puts "Removing cache..."
-    Dir["*-decfirst.cia"].each do |fname| File.delete(fname) end
     Dir["*.ncch"].each do |fname| File.delete(fname) end
 end
 
@@ -120,7 +119,7 @@ Dir["*.cia"].each do |cia|
         puts "CIA Type: Game"
         run_tool("ctrdecrypt", [cia])
 
-        args = ["-f", "cia", "-ignoresign", "-target", "p", "-o", "#{cutn}-decfirst.cia"]
+        args = ["-f", "cia", "-ignoresign", "-target", "p", "-o", "#{cutn}-decrypted.cia"]
         i : UInt8 = 0
         Dir["*.ncch"].sort.each do |ncch|
             args += ["-i", "#{ncch}:#{i}:#{i}"]
@@ -153,8 +152,8 @@ Dir["*.cia"].each do |cia|
         puts "Unsupported CIA"
     end
 
-    Dir["*-decfirst.cia"].each do |decfirst|
-        cutn = decfirst.chomp "-decfirst.cia"
+    Dir["*-decrypted.cia"].each do |decfirst|
+        cutn = decfirst.chomp "-decrypted.cia"
     
         puts "Building decrypted #{cutn} CCI..."
         run_tool("makerom", ["-ciatocci", decfirst, "-o", "#{cutn}-decrypted.cci"])


### PR DESCRIPTION
In case someone ever needs a decrypted `.cia` file in particular for an emulator. I found it pretty annoying to have to sneakily copy the decrypted file while `cia-unix` is running and before it deletes it. It'll take up quite a bit more space in the end, but it would be nice to have the option to have not just `.cci` but also `.cia`. So the average Joe wouldn't need to find some way to convert it to `.cia` too.