### PR TITLE
Select Directory, No-Download Quit & cURL for Apple Silicon

### DIFF
--- a/cia-unix.cr
+++ b/cia-unix.cr
@@ -3,9 +3,15 @@ require "colorize"
 LOG = File.new "cia-unix.log", "w"
 LOG.puts Time.utc.to_s
 
-dir = ARGV.size > 0 && Dir.exists?(ARGV[0]) ? ARGV[0] : "."
+dir = "."
 
-print "Scanning #{dir}\n"
+if ARGV.size > 0
+    if Dir.exists?(ARGV[0])
+        dir = "\"#{File.expand_path(ARGV[0])}\""
+    else
+        print "#{File.expand_path(ARGV[0]).colorize(:yellow)} does not exist.\nDefaulting to #{File.expand_path(dir).colorize(:green)}\n\n"
+    end
+end
 
 # dependencies check
 tools = ["./ctrtool", "./ctrdecrypt", "./makerom", "seeddb.bin"]
@@ -30,7 +36,9 @@ def download_dep
     print "Some #{"tools".colorize.mode(:bold)} are missing, do you want to download them? (y/n): "
     if ["y", "Y"].includes? gets.to_s
         system "./dltools.sh"
-    end 
+    else
+        exit
+    end
 end
 
 # roms presence check

--- a/cia-unix.cr
+++ b/cia-unix.cr
@@ -37,7 +37,10 @@ def download_dep
     if ["y", "Y"].includes? gets.to_s
         system "./dltools.sh"
     else
-        exit
+        print "No tools were downloaded. Continue? (y/n): "
+        if (gets.to_s.chomp.downcase == "n")
+            exit
+        end
     end
 end
 

--- a/dltools.sh
+++ b/dltools.sh
@@ -12,30 +12,30 @@ MAKEROM_VER=0.18.4
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # Apple Silicon
     echo " * Downloading ${BOLD}ctrdecrypt${NORMAL}"
-    wget "https://github.com/shijimasoft/ctrdecrypt/releases/download/v${CTRDECRYPT_VER}/ctrdecrypt-macos-universal.zip" -q
+    curl "https://github.com/shijimasoft/ctrdecrypt/releases/download/v${CTRDECRYPT_VER}/ctrdecrypt-macos-universal.zip" -o .
     echo " * Extracting ${BOLD}ctrdecrypt${NORMAL}"
     unzip -qq "ctrdecrypt-macos-universal.zip" -d "ctrdecrypt-macos-universal"
     mv "ctrdecrypt-macos-universal/ctrdecrypt" "${SCRIPT_DIR}/ctrdecrypt"
     if [[ $(uname -m) == 'arm64' ]]; then
         echo " * Downloading ${BOLD}ctrtool${NORMAL}"
-        wget "https://github.com/3DSGuy/Project_CTR/releases/download/ctrtool-v${CTRTOOL_VER}/ctrtool-v${CTRTOOL_VER}-macos_arm64.zip" -q
+        curl "https://github.com/3DSGuy/Project_CTR/releases/download/ctrtool-v${CTRTOOL_VER}/ctrtool-v${CTRTOOL_VER}-macos_arm64.zip" -o .
         echo " * Extracting ${BOLD}ctrtool${NORMAL}"
         unzip -qq "ctrtool-v${CTRTOOL_VER}-macos_arm64.zip" -d "ctrtool-v${CTRTOOL_VER}-macos_arm64"
         mv "ctrtool-v${CTRTOOL_VER}-macos_arm64/ctrtool" "${SCRIPT_DIR}/ctrtool"
         echo " * Downloading ${BOLD}makerom${NORMAL}"
-        wget "https://github.com/3DSGuy/Project_CTR/releases/download/makerom-v${MAKEROM_VER}/makerom-v${MAKEROM_VER}-macos_arm64.zip" -q
+        curl "https://github.com/3DSGuy/Project_CTR/releases/download/makerom-v${MAKEROM_VER}/makerom-v${MAKEROM_VER}-macos_arm64.zip" -o .
         echo " * Extracting ${BOLD}makerom${NORMAL}"
         unzip -qq "makerom-v${MAKEROM_VER}-macos_arm64.zip" -d "makerom-v${MAKEROM_VER}-macos_arm64"
         mv "makerom-v${MAKEROM_VER}-macos_arm64/makerom" "${SCRIPT_DIR}/makerom"
     # x86_64
     else
         echo " * Downloading ${BOLD}ctrtool${NORMAL}"
-        wget "https://github.com/3DSGuy/Project_CTR/releases/download/ctrtool-v${CTRTOOL_VER}/ctrtool-v${CTRTOOL_VER}-macos_x86_64.zip" -q
+        curl "https://github.com/3DSGuy/Project_CTR/releases/download/ctrtool-v${CTRTOOL_VER}/ctrtool-v${CTRTOOL_VER}-macos_x86_64.zip" -o .
         echo " * Extracting ${BOLD}ctrtool${NORMAL}"
         unzip -qq "ctrtool-v${CTRTOOL_VER}-macos_x86_64.zip" -d "ctrtool-v${CTRTOOL_VER}-macos_x86_64"
         mv "ctrtool-v${CTRTOOL_VER}-macos_x86_64/ctrtool" "${SCRIPT_DIR}/ctrtool"
         echo " * Downloading ${BOLD}makerom${NORMAL}"
-        wget "https://github.com/3DSGuy/Project_CTR/releases/download/makerom-v${MAKEROM_VER}/makerom-v${MAKEROM_VER}-macos_x86_64.zip" -q
+        curl "https://github.com/3DSGuy/Project_CTR/releases/download/makerom-v${MAKEROM_VER}/makerom-v${MAKEROM_VER}-macos_x86_64.zip" -o .
         echo " * Extracting ${BOLD}makerom${NORMAL}"
         unzip -qq "makerom-v${MAKEROM_VER}-macos_x86_64.zip" -d "makerom-v${MAKEROM_VER}-macos_x86_64"
         mv "makerom-v${MAKEROM_VER}-macos_x86_64/makerom" "${SCRIPT_DIR}/makerom"


### PR DESCRIPTION
## Summary
This PR aims to change a few behaviors, namely:

- Allow for users to specify their own directories when running the tool to allow them to avoid moving files to and from the tool's directory;
- Allow the user to quit the tool's execution if the user chose not to download any tools, prompting them if they want to continue;
- Download files using `curl` instead of `wget` for Apple Silicon devices.

## Changes
### Directory Argument
The tool now checks for the first argument and checks if it's an existing directory.
If so, the tool will use that directory to scan for and export files.
Otherwise, the tool will use the current directory (`"."`) as it would normally do.

### Continue Message
The tool now asks, after a user chooses not to download any external tool, if they want to continue or abort.

### cURL for Apple Silicon
The tool now uses `curl` instead of `wget` for Apple Silicon devices.

## Motivation
### Directory Argument
Preventing users from having to move files to and from the tool's directory is a good quality of life feature.

### Continue Message
Continuing without prompting might not be desirable under some situations.

### cURL for Apple Silicon
As stated by user @fillito, `wget` is not pre-installed by default on macOS.
Using `curl` allows for the tool not to force the user to install `brew`.